### PR TITLE
Launch simple MongoDB replica set

### DIFF
--- a/Acornfile
+++ b/Acornfile
@@ -5,11 +5,11 @@ info:        localData.info
 icon:        "./icon.png"
 
 args: {
-  // Name of the default database
-  dbName: "mydb"
+	// Name of the default database
+	dbName: "mydb"
 
-  // Name of the default user
-  dbUser: ""
+	// Name of the default user
+	dbUser: ""
 }
 
 services: db: {
@@ -20,84 +20,92 @@ services: db: {
 	data: dbName: args.dbName
 }
 
-containers: {
-  mongodb: {
-    name: "MongoDB"
-    description: "Container running a MongoDB server"
-    image: "mongo:6.0"
-    ports: "27017/tcp"
-    env: {
-      MONGO_INITDB_ROOT_USERNAME: "secret://admin/username"
-      MONGO_INITDB_ROOT_PASSWORD: "secret://admin/password"
-    }
-    dirs: {
-      "/data/db": "volume://db-data"
-    }
-    probes: [
-      {
-        type:                "liveness"
-        initialDelaySeconds: 10
-        timeoutSeconds:      5
-        tcp:{
-          url: "tcp://localhost:27017"
-        }
-      },   
-    ]
-  }
+containers: mongodb: {
+	name:        "MongoDB"
+	description: "Container running a MongoDB server"
+	image:       "mongo:6.0"
+	ports:       "27017/tcp"
+	env: {
+		MONGO_INITDB_ROOT_USERNAME: "secret://admin/username"
+		MONGO_INITDB_ROOT_PASSWORD: "secret://admin/password"
+		REPLICA_SET_KEY:            "secret://replica-set-key/token"
+	}
+	entrypoint: [ "/acorn/scripts/start-mongodb.sh"]
+	dirs: {
+		"/acorn/scripts": "./scripts"
+		"/data/db":       "volume://mongodb-data"
+	}
+	probes: [
+		{
+			type:                "liveness"
+			initialDelaySeconds: 10
+			timeoutSeconds:      5
+			tcp: {
+				url: "tcp://localhost:27017"
+			}
+		},
+	]
 }
 
-volumes: {
-  "db-data": {}
+jobs: {
+	"init-db": {
+		image: "mongo:6.0"
+		env: {
+			MONGO_INITDB_ROOT_USERNAME: "secret://admin/username"
+			MONGO_INITDB_ROOT_PASSWORD: "secret://admin/password"
+			MONGO_USERNAME:             "secret://user/username"
+			MONGO_PASSWORD:             "secret://user/password"
+			MONGO_HOST:                 "mongodb"
+			MONGO_DATABASE:             args.dbName
+		}
+		dependsOn: ["mongodb"]
+		entrypoint: ["/acorn/scripts/render.sh"]
+		dirs: "/acorn/scripts": "./scripts"
+		files: {
+			"/var/run/replica-set": """
+   {
+      _id: "rs0",
+      version: 1,
+      members: [ { _id: 0, host: "mongodb:27017" } ]
+   }
+		"""
+		}
+	}
 }
 
-jobs: "create-user": {
-  build: context: "."
-  env: {
-    MONGO_INITDB_ROOT_USERNAME: "secret://admin/username"
-    MONGO_INITDB_ROOT_PASSWORD: "secret://admin/password"
-    MONGO_USERNAME: "secret://user/username"
-    MONGO_PASSWORD: "secret://user/password"
-    MONGO_DATABASE: args.dbName
-  }
-}
+volumes: "mongodb-data": {}
 
 secrets: {
-    admin: {
-        name: "credentials of the admin user"
-        type: "basic"
-        params: {
-            passwordLength: 10
-            passwordCharacters: "A-Za-z0-9"
-        }
-        data: {  
-            username: "root"
-            password: ""
-        }
-    }
-}
+	"replica-set-key": type: "token"
 
-secrets: {
-    user: {
-        name: "credentials of the additional user"
-        type: "basic"
-        params: {
-            usernameLength: 7
-            usernameCharacters: "a-z"
-            passwordLength: 10
-            passwordCharacters: "A-Za-z0-9"
-        }
-        data: {  
-            username: std.ifelse(args.dbUser != "", args.dbUser, "")
-            password: ""
-        }
-    }
-}
+	admin: {
+		name: "credentials of the admin user"
+		type: "basic"
+		params: {
+			passwordLength:     10
+			passwordCharacters: "A-Za-z0-9"
+		}
+		data: {
+			username: "root"
+			password: ""
+		}
+	}
 
-localData: readinessProbeCommand: [
-  "bash",
-  "-c",
-  "mongosh --quiet --eval \"db.adminCommand('ping')\""
-]
+	user: {
+		name: "credentials of the additional user"
+		type: "basic"
+		params: {
+			usernameLength:     7
+			usernameCharacters: "a-z"
+			passwordLength:     10
+			passwordCharacters: "A-Za-z0-9"
+		}
+		data: {
+			username: std.ifelse(args.dbUser != "", args.dbUser, "")
+			password: ""
+		}
+	}
+}
 
 localData: info: """
 	## Usage
@@ -117,4 +125,3 @@ localData: info: """
 		}
 	}
 	"""
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,0 @@
-FROM mongo:6.0
-COPY ./scripts/render.sh /acorn/scripts/render.sh
-ENTRYPOINT ["/acorn/scripts/render.sh"]

--- a/scripts/render.sh
+++ b/scripts/render.sh
@@ -4,13 +4,20 @@
 # Wait for mongodb container to be ready
 while true; do
   echo "[render.sh] wait for db to be ready"
-  mongosh --quiet --host "mongodb" --username ${MONGO_INITDB_ROOT_USERNAME} --password ${MONGO_INITDB_ROOT_PASSWORD} --authenticationDatabase admin --eval "db.runCommand({ ping: 1 })"
+  mongosh --quiet --host "${MONGO_HOST}" --username "${MONGO_INITDB_ROOT_USERNAME}" --password "${MONGO_INITDB_ROOT_PASSWORD}" --authenticationDatabase admin --eval "db.runCommand({ ping: 1 })"
   if [ $? -eq 0 ]; then
       echo "[render.sh] db is ready"
       break
   fi
   sleep 2
 done
+
+# Initiate replica set
+if [ -f /var/run/replica-set ]; then
+  echo "[render.sh] initiating replica set"
+  mongosh --quiet --host "${MONGO_HOST}" --username "${MONGO_INITDB_ROOT_USERNAME}" --password "${MONGO_INITDB_ROOT_PASSWORD}" --authenticationDatabase admin --eval "rs.initiate($(cat /var/run/replica-set))"
+  echo "[render.sh] replica set initiate status: [$?]"
+fi
 
 # Script to create user
 cat <<EOF > /tmp/create-user.js
@@ -21,5 +28,5 @@ EOF
 
 # Create user
 echo "[render.sh] about to create user"
-mongosh --host "mongodb" --username ${MONGO_INITDB_ROOT_USERNAME} --password ${MONGO_INITDB_ROOT_PASSWORD} --authenticationDatabase admin --eval "$(cat /tmp/create-user.js)"
+mongosh --host "${MONGO_HOST}" --username "${MONGO_INITDB_ROOT_USERNAME}" --password "${MONGO_INITDB_ROOT_PASSWORD}" --authenticationDatabase admin --eval "$(cat /tmp/create-user.js)"
 echo "[render.sh] user creation status: [$?]"

--- a/scripts/start-mongodb.sh
+++ b/scripts/start-mongodb.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# set -o pipefail
+
+# Replica set keys must be between 6 and 1024 characters in length and consist of only valid base64 characters.
+# See https://www.mongodb.com/docs/v6.2/tutorial/deploy-replica-set-with-keyfile-access-control/#create-a-keyfile
+# for details.
+echo -n "${REPLICA_SET_KEY}" | base64 > /replica-set-key
+chmod 0400 /replica-set-key
+chown 999:999 /replica-set-key
+
+/usr/local/bin/docker-entrypoint.sh mongod --replSet rs0 --bind_ip localhost,mongodb --keyFile /replica-set-key


### PR DESCRIPTION
Configure the MongoDB deployment launched by this Acorn to run as
a MongoDB replica set of size 1, using keyfiles for member authentication.
Running as a replica set enables MongoDB transactions and will
allow clients that depend on them to consume this Acorn; e.g. Prisma's
MongoDB database connector.

Addresses #6 